### PR TITLE
Add Ant Design Vue control plane frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.log
+.DS_Store
+.idea/
+.vscode/
+.env
+.venv/
+temp-profile-*/
+playwright_screenshot.png
+form_demo.png
+node_modules/
+dist/
+frontend/node_modules/
+frontend/dist/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 FlashAgent
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,85 @@
 # FlashAgent
+
+FlashAgent is a collection of end-to-end examples that demonstrate how to combine the
+[`browser-use`](https://github.com/browser-use/browser-use) agent framework with Playwright,
+custom Chrome instances, and containerised runtimes. The goal of this repository is to
+provide copy-and-run samples for developers who want to explore advanced browser
+automation scenarios, from orchestrating Playwright actions through Browser-Use to building
+Docker images that package every dependency required by an agentic stack.
+
+## Repository structure
+
+- [`frontend/`](frontend/) – Ant Design Vue dashboard that orchestrates MCP servers,
+  terminals, and workspace previews for FlashAgent scenarios.
+- [`examples/`](examples/) – Python scripts that highlight specific integration patterns
+  between Browser-Use, Playwright, and shared Chrome sessions.
+- [`docker/`](docker/) – Dockerfiles and helper scripts for producing reproducible images
+  ranging from minimal Python environments up to full VS Code based workspaces.
+
+Each example is designed to be self-contained, well documented, and ready for adaptation to
+real-world automation tasks.
+
+## Getting started
+
+FlashAgent now ships with a Vue 3 + Ant Design Vue control plane and the original
+Python examples. You can run either side independently.
+
+### Frontend workspace (Vue 3)
+
+1. Install dependencies and start the Vite dev server:
+
+   ```bash
+   cd frontend
+   npm install
+   npm run dev
+   ```
+
+2. Open the printed URL (defaults to <http://localhost:5173>) to explore the
+   dashboard. The UI ships with mocked data sources so it renders immediately,
+   and it wires in components for MCP server management, a terminal console,
+   search insights, and a VS Code inspired file explorer.
+
+3. When you are ready to build for production:
+
+   ```bash
+   npm run build
+   npm run preview
+   ```
+
+### Python automation examples
+
+1. Create and activate a virtual environment (we recommend
+   [`uv`](https://github.com/astral-sh/uv) for speed and reproducibility).
+
+   ```bash
+   uv venv
+   source .venv/bin/activate
+   uv pip install -r requirements.txt
+   ```
+
+2. Install the Playwright browsers that are required by the demos:
+
+   ```bash
+   playwright install chromium
+   ```
+
+3. Export your OpenAI compatible API key so that the Browser-Use agent can talk to an LLM:
+
+   ```bash
+   export OPENAI_API_KEY="sk-..."
+   ```
+
+4. Execute any script inside `examples/` to experiment with a scenario. For instance, the
+   advanced integration demo can be launched with:
+
+   ```bash
+   python examples/advanced_playwright_integration.py
+   ```
+
+The Dockerfiles under `docker/` provide ready-to-build images when a fully containerised
+experience is preferred.
+
+## License
+
+This repository is distributed under the MIT License. See the [`LICENSE`](LICENSE) file for
+full details.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,34 @@
+FROM python:3.12-slim
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        wget \
+        fonts-liberation \
+        libnss3 \
+        libatk1.0-0 \
+        libatk-bridge2.0-0 \
+        libdrm2 \
+        libxkbcommon0 \
+        libgbm1 \
+        libxshmfence1 \
+        libasound2 \
+        libxdamage1 \
+        libxrandr2 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir uv
+
+WORKDIR /app
+COPY requirements.txt ./
+RUN uv pip install -r requirements.txt
+
+RUN PLAYWRIGHT_BROWSERS_PATH=/opt/playwright playwright install chromium --with-deps --no-shell
+
+COPY . .
+
+CMD ["python", "examples/advanced_playwright_integration.py"]

--- a/docker/Dockerfile.fast
+++ b/docker/Dockerfile.fast
@@ -1,0 +1,11 @@
+ARG BASE_TAG=latest
+FROM browseruse/base-python-deps:${BASE_TAG}
+
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+
+COPY . .
+
+RUN uv pip install -r requirements.txt
+
+CMD ["python", "examples/advanced_playwright_integration.py"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,27 @@
+# Docker setup for FlashAgent
+
+This directory contains a fast, layered Docker build system designed to package
+the Browser-Use/Playwright stack. Two Dockerfiles are provided:
+
+- `Dockerfile` – A self-contained build that installs every dependency from
+  scratch. Suitable when caching base images is not possible.
+- `Dockerfile.fast` – Relies on the base images defined under `base-images/` to
+  achieve < 30 second rebuilds once the base layers are prepared.
+
+To build the base images run:
+
+```bash
+./docker/build-base-images.sh
+```
+
+Then build the final image:
+
+```bash
+docker build -f Dockerfile.fast -t browseruse .
+```
+
+Or fall back to the slower but self-contained Dockerfile:
+
+```bash
+docker build -t browseruse .
+```

--- a/docker/base-images/chromium/Dockerfile
+++ b/docker/base-images/chromium/Dockerfile
@@ -1,0 +1,11 @@
+ARG BASE_TAG=latest
+FROM browseruse/base-system:${BASE_TAG}
+
+WORKDIR /tmp
+
+RUN --mount=type=cache,target=/root/.cache,sharing=locked \
+    pip install --no-cache-dir playwright && \
+    PLAYWRIGHT_BROWSERS_PATH=/opt/playwright playwright install chromium --with-deps --no-shell && \
+    ln -sf /opt/playwright/chromium-*/chrome-linux/chrome /usr/bin/chromium-browser && \
+    chmod -R 755 /opt/playwright && \
+    pip uninstall -y playwright

--- a/docker/base-images/python-deps/Dockerfile
+++ b/docker/base-images/python-deps/Dockerfile
@@ -1,0 +1,14 @@
+ARG BASE_TAG=latest
+FROM browseruse/base-chromium:${BASE_TAG}
+
+ENV PYTHONUNBUFFERED=1 \
+    PATH="/app/.venv/bin:$PATH" \
+    PLAYWRIGHT_BROWSERS_PATH=/opt/playwright
+
+WORKDIR /app
+COPY requirements.txt ./
+
+RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
+    uv venv && \
+    uv pip install -r requirements.txt && \
+    rm requirements.txt

--- a/docker/base-images/system/Dockerfile
+++ b/docker/base-images/system/Dockerfile
@@ -1,0 +1,29 @@
+FROM python:3.12-slim
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        wget \
+        git \
+        fonts-liberation \
+        libnss3 \
+        libatk1.0-0 \
+        libatk-bridge2.0-0 \
+        libdrm2 \
+        libxkbcommon0 \
+        libgbm1 \
+        libxshmfence1 \
+        libasound2 \
+        libxdamage1 \
+        libxrandr2 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uvx /bin/uvx
+
+ENV PATH="/root/.local/bin:$PATH" \
+    PYTHONUNBUFFERED=1

--- a/docker/build-base-images.sh
+++ b/docker/build-base-images.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_TAG="latest"
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+build_image() {
+  local dockerfile="$1"
+  local tag="$2"
+  echo "Building ${tag} from ${dockerfile}"
+  docker build \
+    -f "${ROOT_DIR}/${dockerfile}" \
+    -t "${tag}:${BASE_TAG}" \
+    "${ROOT_DIR}"
+}
+
+build_image "docker/base-images/system/Dockerfile" "browseruse/base-system"
+build_image "docker/base-images/chromium/Dockerfile" "browseruse/base-chromium"
+build_image "docker/base-images/python-deps/Dockerfile" "browseruse/base-python-deps"

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,19 @@
+# Browser-Use demonstration scripts
+
+The scripts in this directory illustrate different ways to connect Browser-Use
+agents to Chrome and Playwright instances.
+
+## Available demos
+
+- `advanced_playwright_integration.py` – Launches a shared Chrome instance,
+  registers Playwright-powered actions, and demonstrates end-to-end task
+  execution.
+- `connect_existing_chrome.py` – Reuses an already running Chrome profile and
+  executes a simple DuckDuckGo search.
+- `cdp_duckduckgo_demo.py` – Uses the Chrome DevTools Protocol (CDP) endpoint at
+  `http://localhost:9222` to run a Browser-Use agent without launching a new
+  browser process.
+- `multi_agent_parallel_demo.py` – Spawns three Browser-Use agents in parallel,
+  each with its own temporary profile directory.
+
+All scripts expect the `OPENAI_API_KEY` environment variable to be set.

--- a/examples/advanced_playwright_integration.py
+++ b/examples/advanced_playwright_integration.py
@@ -1,0 +1,304 @@
+"""Advanced Browser-Use + Playwright demo.
+
+This script shows how to share a Chrome instance between Browser-Use and
+Playwright. Custom Browser-Use actions leverage Playwright APIs for precise
+interactions such as form filling, screenshots, and targeted text extraction.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+from typing import Any
+
+import aiohttp
+from pydantic import BaseModel, Field
+from playwright.async_api import Browser, Page, async_playwright
+
+from browser_use import Agent, BrowserSession, ChatOpenAI, Tools
+from browser_use.agent.views import ActionResult
+
+playwright_browser: Browser | None = None
+playwright_page: Page | None = None
+
+
+class PlaywrightFillFormAction(BaseModel):
+    """Parameters for filling a demo form with Playwright."""
+
+    customer_name: str = Field(..., description="Customer name to fill")
+    phone_number: str = Field(..., description="Phone number to fill")
+    email: str = Field(..., description="Email address to fill")
+    size_option: str = Field(..., description="Size option (small/medium/large)")
+
+
+class PlaywrightScreenshotAction(BaseModel):
+    """Parameters for capturing a screenshot using Playwright."""
+
+    filename: str = Field(
+        default="playwright_screenshot.png",
+        description="Filename for screenshot",
+    )
+    quality: int | None = Field(
+        default=None,
+        description="JPEG quality (1-100), only used for JPEG files",
+    )
+
+
+class PlaywrightGetTextAction(BaseModel):
+    """Parameters for fetching text content via a Playwright selector."""
+
+    selector: str = Field(..., description='CSS selector or "title" for page title')
+
+
+tools = Tools()
+
+
+async def start_chrome_with_debug_port(port: int = 9222) -> asyncio.subprocess.Process:
+    """Start Chrome with the remote debugging port enabled."""
+
+    user_data_dir = tempfile.mkdtemp(prefix="chrome_cdp_")
+    chrome_paths = [
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+        "/usr/bin/google-chrome",
+        "/usr/bin/chromium-browser",
+        "chrome",
+        "chromium",
+    ]
+
+    chrome_exe: str | None = None
+    for path in chrome_paths:
+        if os.path.exists(path) or path in {"chrome", "chromium"}:
+            try:
+                process = await asyncio.create_subprocess_exec(
+                    path,
+                    "--version",
+                    stdout=asyncio.subprocess.DEVNULL,
+                    stderr=asyncio.subprocess.DEVNULL,
+                )
+                await process.wait()
+                chrome_exe = path
+                break
+            except Exception:
+                continue
+
+    if not chrome_exe:
+        raise RuntimeError("Chrome executable not found. Install Chrome or Chromium.")
+
+    process = await asyncio.create_subprocess_exec(
+        chrome_exe,
+        f"--remote-debugging-port={port}",
+        f"--user-data-dir={user_data_dir}",
+        "--no-first-run",
+        "--no-default-browser-check",
+        "--disable-extensions",
+        "about:blank",
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+
+    for _ in range(20):
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    f"http://localhost:{port}/json/version",
+                    timeout=aiohttp.ClientTimeout(total=1),
+                ) as response:
+                    if response.status == 200:
+                        return process
+        except Exception:
+            await asyncio.sleep(1)
+        else:
+            break
+    else:
+        process.terminate()
+        raise RuntimeError("Chrome failed to start with CDP")
+
+    return process
+
+
+async def connect_playwright_to_cdp(cdp_url: str) -> None:
+    """Attach Playwright to the Chrome instance launched for Browser-Use."""
+
+    global playwright_browser, playwright_page
+    playwright = await async_playwright().start()
+    playwright_browser = await playwright.chromium.connect_over_cdp(cdp_url)
+
+    if playwright_browser.contexts and playwright_browser.contexts[0].pages:
+        playwright_page = playwright_browser.contexts[0].pages[0]
+    else:
+        context = await playwright_browser.new_context()
+        playwright_page = await context.new_page()
+
+
+@tools.registry.action(
+    "Fill a form using Playwright selectors for precise interaction.",
+    param_model=PlaywrightFillFormAction,
+)
+async def playwright_fill_form(
+    params: PlaywrightFillFormAction, browser_session: BrowserSession
+) -> ActionResult:
+    """Fill the demo form with Playwright and report the captured values."""
+
+    del browser_session
+    if not playwright_page:
+        return ActionResult(error="Playwright not connected. Run setup first.")
+
+    try:
+        await playwright_page.wait_for_selector('input[name="custname"]', timeout=10000)
+        await playwright_page.fill('input[name="custname"]', params.customer_name)
+        await playwright_page.fill('input[name="custtel"]', params.phone_number)
+        await playwright_page.fill('input[name="custemail"]', params.email)
+
+        size_select = playwright_page.locator('select[name="size"]')
+        size_radio = playwright_page.locator(
+            f'input[name="size"][value="{params.size_option}"]'
+        )
+
+        if await size_select.count() > 0:
+            await playwright_page.select_option('select[name="size"]', params.size_option)
+        elif await size_radio.count() > 0:
+            await size_radio.check()
+        else:
+            raise ValueError(f"Could not find size input for value: {params.size_option}")
+
+        checked_value: str | None
+        if await size_select.count() > 0:
+            checked_value = await playwright_page.input_value('select[name="size"]')
+        else:
+            checked_radio = playwright_page.locator('input[name="size"]:checked')
+            checked_value = await checked_radio.get_attribute("value")
+
+        payload = {
+            "name": await playwright_page.input_value('input[name="custname"]'),
+            "phone": await playwright_page.input_value('input[name="custtel"]'),
+            "email": await playwright_page.input_value('input[name="custemail"]'),
+            "size": checked_value,
+        }
+
+        message = f"Form filled successfully with Playwright: {payload}"
+        return ActionResult(
+            extracted_content=message,
+            include_in_memory=True,
+            long_term_memory=f"Filled form with: {payload}",
+        )
+    except Exception as exc:  # noqa: BLE001
+        return ActionResult(error=f"Playwright form filling failed: {exc}")
+
+
+@tools.registry.action(
+    "Capture a screenshot using Playwright.",
+    param_model=PlaywrightScreenshotAction,
+)
+async def playwright_screenshot(
+    params: PlaywrightScreenshotAction, browser_session: BrowserSession
+) -> ActionResult:
+    """Capture a full-page screenshot with optional JPEG quality control."""
+
+    del browser_session
+    if not playwright_page:
+        return ActionResult(error="Playwright not connected. Run setup first.")
+
+    try:
+        kwargs: dict[str, Any] = {"path": params.filename, "full_page": True}
+        if params.quality is not None and params.filename.lower().endswith((".jpg", ".jpeg")):
+            kwargs["quality"] = params.quality
+        await playwright_page.screenshot(**kwargs)
+        message = f"Screenshot saved as {params.filename} using Playwright"
+        return ActionResult(
+            extracted_content=message,
+            include_in_memory=True,
+            long_term_memory=f"Screenshot saved: {params.filename}",
+        )
+    except Exception as exc:  # noqa: BLE001
+        return ActionResult(error=f"Playwright screenshot failed: {exc}")
+
+
+@tools.registry.action(
+    "Extract text using Playwright selectors.",
+    param_model=PlaywrightGetTextAction,
+)
+async def playwright_get_text(
+    params: PlaywrightGetTextAction, browser_session: BrowserSession
+) -> ActionResult:
+    """Retrieve text content for a given selector or the page title."""
+
+    del browser_session
+    if not playwright_page:
+        return ActionResult(error="Playwright not connected. Run setup first.")
+
+    try:
+        if params.selector.lower() == "title":
+            text_content = await playwright_page.title()
+            payload = {
+                "selector": "title",
+                "text_content": text_content,
+                "inner_text": text_content,
+                "tag_name": "TITLE",
+                "is_visible": True,
+            }
+        else:
+            element = playwright_page.locator(params.selector).first
+            if await element.count() == 0:
+                return ActionResult(error=f"No element found with selector: {params.selector}")
+
+            text_content = await element.text_content()
+            payload = {
+                "selector": params.selector,
+                "text_content": text_content,
+                "inner_text": await element.inner_text(),
+                "tag_name": await element.evaluate("el => el.tagName"),
+                "is_visible": await element.is_visible(),
+            }
+
+        message = f"Extracted text using Playwright: {payload}"
+        return ActionResult(
+            extracted_content=str(payload),
+            include_in_memory=True,
+            long_term_memory=f"Extracted from {payload['selector']}: {payload['text_content']}",
+        )
+    except Exception as exc:  # noqa: BLE001
+        return ActionResult(error=f"Playwright text extraction failed: {exc}")
+
+
+def build_agent(port: int) -> Agent:
+    """Initialise the Browser-Use agent with custom Playwright powered tools."""
+
+    session = BrowserSession(cdp_url=f"http://localhost:{port}")
+    return Agent(
+        task=(
+            "Demonstrate Playwright + Browser-Use integration by filling a form, "
+            "capturing a screenshot, extracting the page title, and submitting the form."
+        ),
+        llm=ChatOpenAI(model="gpt-4.1-mini"),
+        tools=tools,
+        browser_session=session,
+    )
+
+
+async def main() -> None:
+    """Run the integration demo end-to-end."""
+
+    port = 9222
+    chrome_process: asyncio.subprocess.Process | None = None
+
+    try:
+        chrome_process = await start_chrome_with_debug_port(port=port)
+        await connect_playwright_to_cdp(f"http://localhost:{port}")
+        agent = build_agent(port)
+        result = await agent.run()
+        print(f"Integration demo completed: {result}")
+        await asyncio.sleep(2)
+    finally:
+        if playwright_browser:
+            await playwright_browser.close()
+        if chrome_process:
+            chrome_process.terminate()
+            try:
+                await asyncio.wait_for(chrome_process.wait(), timeout=5)
+            except asyncio.TimeoutError:
+                chrome_process.kill()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/cdp_duckduckgo_demo.py
+++ b/examples/cdp_duckduckgo_demo.py
@@ -1,0 +1,36 @@
+"""Simple Browser-Use demo that connects via an existing CDP endpoint."""
+
+import asyncio
+import os
+import sys
+
+from dotenv import load_dotenv
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+load_dotenv()
+
+from browser_use import Agent, Tools  # noqa: E402
+from browser_use.browser import BrowserProfile, BrowserSession  # noqa: E402
+from browser_use.llm import ChatOpenAI  # noqa: E402
+
+
+async def main() -> None:
+    browser_session = BrowserSession(
+        browser_profile=BrowserProfile(cdp_url="http://localhost:9222", is_local=True)
+    )
+    tools = Tools()
+
+    agent = Agent(
+        task='Visit https://duckduckgo.com and search for "browser-use founders"',
+        llm=ChatOpenAI(model="gpt-4.1-mini"),
+        tools=tools,
+        browser_session=browser_session,
+    )
+
+    await agent.run()
+    await browser_session.kill()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/connect_existing_chrome.py
+++ b/examples/connect_existing_chrome.py
@@ -1,0 +1,39 @@
+"""Connect Browser-Use to an already running Chrome profile."""
+
+import asyncio
+import os
+import sys
+
+from dotenv import load_dotenv
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+load_dotenv()
+
+from browser_use import Agent, Browser, ChatOpenAI  # noqa: E402
+
+
+def build_browser() -> Browser:
+    """Attach to a locally running Chrome profile using Browser-Use."""
+
+    return Browser(
+        executable_path="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+        user_data_dir="~/Library/Application Support/Google/Chrome",
+        profile_directory="Default",
+    )
+
+
+async def main() -> None:
+    """Search DuckDuckGo for browser-use founders."""
+
+    browser = build_browser()
+    agent = Agent(
+        llm=ChatOpenAI(model="gpt-4.1-mini"),
+        task='Visit https://duckduckgo.com and search for "browser-use founders"',
+        browser=browser,
+    )
+    await agent.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/multi_agent_parallel_demo.py
+++ b/examples/multi_agent_parallel_demo.py
@@ -1,0 +1,36 @@
+"""Run multiple Browser-Use agents in parallel."""
+
+import asyncio
+
+from browser_use import Agent, Browser, ChatOpenAI
+
+
+async def main() -> None:
+    browsers = [
+        Browser(user_data_dir=f"./temp-profile-{i}", headless=False) for i in range(3)
+    ]
+
+    agents = [
+        Agent(
+            task='Search for "browser automation" on Google',
+            browser=browsers[0],
+            llm=ChatOpenAI(model="gpt-4.1-mini"),
+        ),
+        Agent(
+            task='Search for "AI agents" on DuckDuckGo',
+            browser=browsers[1],
+            llm=ChatOpenAI(model="gpt-4.1-mini"),
+        ),
+        Agent(
+            task='Visit Wikipedia and search for "web scraping"',
+            browser=browsers[2],
+            llm=ChatOpenAI(model="gpt-4.1-mini"),
+        ),
+    ]
+
+    results = await asyncio.gather(*(agent.run() for agent in agents), return_exceptions=True)
+    print("All agents completed!", results)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>FlashAgent Workspace</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,2109 @@
+{
+  "name": "flashagent-frontend",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "flashagent-frontend",
+      "version": "0.1.0",
+      "dependencies": {
+        "@ant-design/icons-vue": "^7.0.1",
+        "@xterm/addon-fit": "^0.10.0",
+        "@xterm/xterm": "^5.3.0",
+        "ant-design-vue": "^4.2.1",
+        "highlight.js": "^11.9.0",
+        "mitt": "^3.0.1",
+        "pinia": "^2.1.7",
+        "vue": "^3.4.21",
+        "vue-i18n": "^9.13.1"
+      },
+      "devDependencies": {
+        "@types/node": "^20.12.7",
+        "@vitejs/plugin-vue": "^5.0.4",
+        "sass": "^1.70.0",
+        "typescript": "^5.4.2",
+        "vite": "^5.2.0"
+      }
+    },
+    "node_modules/@ant-design/colors": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-6.0.0.tgz",
+      "integrity": "sha512-qAZRvPzfdWHtfameEGP2Qvuf838NhergR35o+EuVyB5XvSA98xod5r4utvi4TJ3ywmevm290g9nsCG5MryrdWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ctrl/tinycolor": "^3.4.0"
+      }
+    },
+    "node_modules/@ant-design/icons-svg": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.4.2.tgz",
+      "integrity": "sha512-vHbT+zJEVzllwP+CM+ul7reTEfBR0vgxFe7+lREAsAA7YGsYpboiq2sQNeQeRvh09GfQgs/GyFEvZpJ9cLXpXA==",
+      "license": "MIT"
+    },
+    "node_modules/@ant-design/icons-vue": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons-vue/-/icons-vue-7.0.1.tgz",
+      "integrity": "sha512-eCqY2unfZK6Fe02AwFlDHLfoyEFreP6rBwAZMIJ1LugmfMiVgwWDYlp1YsRugaPtICYOabV1iWxXdP12u9U43Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@ant-design/colors": "^6.0.0",
+        "@ant-design/icons-svg": "^4.2.1"
+      },
+      "peerDependencies": {
+        "vue": ">=3.0.3"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@ctrl/tinycolor": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz",
+      "integrity": "sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
+      "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==",
+      "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@intlify/core-base": {
+      "version": "9.14.5",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.14.5.tgz",
+      "integrity": "sha512-5ah5FqZG4pOoHjkvs8mjtv+gPKYU0zCISaYNjBNNqYiaITxW8ZtVih3GS/oTOqN8d9/mDLyrjD46GBApNxmlsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/message-compiler": "9.14.5",
+        "@intlify/shared": "9.14.5"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/message-compiler": {
+      "version": "9.14.5",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.14.5.tgz",
+      "integrity": "sha512-IHzgEu61/YIpQV5Pc3aRWScDcnFKWvQA9kigcINcCBXN8mbW+vk9SK+lDxA6STzKQsVJxUPg9ACC52pKKo3SVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/shared": "9.14.5",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/shared": {
+      "version": "9.14.5",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.14.5.tgz",
+      "integrity": "sha512-9gB+E53BYuAEMhbCAxVgG38EZrk59sxBtv3jSizNL2hEWlgjBjAw1AwpLHtNaeda12pe6W20OGEa0TwuMSRbyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@parcel/watcher": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
+      "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^1.0.3",
+        "is-glob": "^4.0.3",
+        "micromatch": "^4.0.5",
+        "node-addon-api": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.1",
+        "@parcel/watcher-darwin-arm64": "2.5.1",
+        "@parcel/watcher-darwin-x64": "2.5.1",
+        "@parcel/watcher-freebsd-x64": "2.5.1",
+        "@parcel/watcher-linux-arm-glibc": "2.5.1",
+        "@parcel/watcher-linux-arm-musl": "2.5.1",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.1",
+        "@parcel/watcher-linux-arm64-musl": "2.5.1",
+        "@parcel/watcher-linux-x64-glibc": "2.5.1",
+        "@parcel/watcher-linux-x64-musl": "2.5.1",
+        "@parcel/watcher-win32-arm64": "2.5.1",
+        "@parcel/watcher-win32-ia32": "2.5.1",
+        "@parcel/watcher-win32-x64": "2.5.1"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz",
+      "integrity": "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz",
+      "integrity": "sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz",
+      "integrity": "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz",
+      "integrity": "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz",
+      "integrity": "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz",
+      "integrity": "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz",
+      "integrity": "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz",
+      "integrity": "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz",
+      "integrity": "sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz",
+      "integrity": "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz",
+      "integrity": "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz",
+      "integrity": "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz",
+      "integrity": "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.2.tgz",
+      "integrity": "sha512-o3pcKzJgSGt4d74lSZ+OCnHwkKBeAbFDmbEm5gg70eA8VkyCuC/zV9TwBnmw6VjDlRdF4Pshfb+WE9E6XY1PoQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.2.tgz",
+      "integrity": "sha512-cqFSWO5tX2vhC9hJTK8WAiPIm4Q8q/cU8j2HQA0L3E1uXvBYbOZMhE2oFL8n2pKB5sOCHY6bBuHaRwG7TkfJyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.2.tgz",
+      "integrity": "sha512-vngduywkkv8Fkh3wIZf5nFPXzWsNsVu1kvtLETWxTFf/5opZmflgVSeLgdHR56RQh71xhPhWoOkEBvbehwTlVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.2.tgz",
+      "integrity": "sha512-h11KikYrUCYTrDj6h939hhMNlqU2fo/X4NB0OZcys3fya49o1hmFaczAiJWVAFgrM1NCP6RrO7lQKeVYSKBPSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.2.tgz",
+      "integrity": "sha512-/eg4CI61ZUkLXxMHyVlmlGrSQZ34xqWlZNW43IAU4RmdzWEx0mQJ2mN/Cx4IHLVZFL6UBGAh+/GXhgvGb+nVxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.2.tgz",
+      "integrity": "sha512-QOWgFH5X9+p+S1NAfOqc0z8qEpJIoUHf7OWjNUGOeW18Mx22lAUOiA9b6r2/vpzLdfxi/f+VWsYjUOMCcYh0Ng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.2.tgz",
+      "integrity": "sha512-kDWSPafToDd8LcBYd1t5jw7bD5Ojcu12S3uT372e5HKPzQt532vW+rGFFOaiR0opxePyUkHrwz8iWYEyH1IIQA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.2.tgz",
+      "integrity": "sha512-gKm7Mk9wCv6/rkzwCiUC4KnevYhlf8ztBrDRT9g/u//1fZLapSRc+eDZj2Eu2wpJ+0RzUKgtNijnVIB4ZxyL+w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.2.tgz",
+      "integrity": "sha512-66lA8vnj5mB/rtDNwPgrrKUOtCLVQypkyDa2gMfOefXK6rcZAxKLO9Fy3GkW8VkPnENv9hBkNOFfGLf6rNKGUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.2.tgz",
+      "integrity": "sha512-s+OPucLNdJHvuZHuIz2WwncJ+SfWHFEmlC5nKMUgAelUeBUnlB4wt7rXWiyG4Zn07uY2Dd+SGyVa9oyLkVGOjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.2.tgz",
+      "integrity": "sha512-8wTRM3+gVMDLLDdaT6tKmOE3lJyRy9NpJUS/ZRWmLCmOPIJhVyXwjBo+XbrrwtV33Em1/eCTd5TuGJm4+DmYjw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.2.tgz",
+      "integrity": "sha512-6yqEfgJ1anIeuP2P/zhtfBlDpXUb80t8DpbYwXQ3bQd95JMvUaqiX+fKqYqUwZXqdJDd8xdilNtsHM2N0cFm6A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.2.tgz",
+      "integrity": "sha512-sshYUiYVSEI2B6dp4jMncwxbrUqRdNApF2c3bhtLAU0qA8Lrri0p0NauOsTWh3yCCCDyBOjESHMExonp7Nzc0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.2.tgz",
+      "integrity": "sha512-duBLgd+3pqC4MMwBrKkFxaZerUxZcYApQVC5SdbF5/e/589GwVvlRUnyqMFbM8iUSb1BaoX/3fRL7hB9m2Pj8Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.2.tgz",
+      "integrity": "sha512-tzhYJJidDUVGMgVyE+PmxENPHlvvqm1KILjjZhB8/xHYqAGeizh3GBGf9u6WdJpZrz1aCpIIHG0LgJgH9rVjHQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.2.tgz",
+      "integrity": "sha512-opH8GSUuVcCSSyHHcl5hELrmnk4waZoVpgn/4FDao9iyE4WpQhyWJ5ryl5M3ocp4qkRuHfyXnGqg8M9oKCEKRA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.2.tgz",
+      "integrity": "sha512-LSeBHnGli1pPKVJ79ZVJgeZWWZXkEe/5o8kcn23M8eMKCUANejchJbF/JqzM4RRjOJfNRhKJk8FuqL1GKjF5oQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.2.tgz",
+      "integrity": "sha512-uPj7MQ6/s+/GOpolavm6BPo+6CbhbKYyZHUDvZ/SmJM7pfDBgdGisFX3bY/CBDMg2ZO4utfhlApkSfZ92yXw7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.2.tgz",
+      "integrity": "sha512-Z9MUCrSgIaUeeHAiNkm3cQyst2UhzjPraR3gYYfOjAuZI7tcFRTOD+4cHLPoS/3qinchth+V56vtqz1Tv+6KPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.2.tgz",
+      "integrity": "sha512-+GnYBmpjldD3XQd+HMejo+0gJGwYIOfFeoBQv32xF/RUIvccUz20/V6Otdv+57NE70D5pa8W/jVGDoGq0oON4A==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.2.tgz",
+      "integrity": "sha512-ApXFKluSB6kDQkAqZOKXBjiaqdF1BlKi+/eqnYe9Ee7U2K3pUDKsIyr8EYm/QDHTJIM+4X+lI0gJc3TTRhd+dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.2.tgz",
+      "integrity": "sha512-ARz+Bs8kY6FtitYM96PqPEVvPXqEZmPZsSkXvyX19YzDqkCaIlhCieLLMI5hxO9SRZ2XtCtm8wxhy0iJ2jxNfw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@simonwep/pickr": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@simonwep/pickr/-/pickr-1.8.2.tgz",
+      "integrity": "sha512-/l5w8BIkrpP6n1xsetx9MWPWlU6OblN5YgZZphxan0Tq4BByTCETL6lyIeY8lagalS2Nbt4F2W034KHLIiunKA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-js": "^3.15.1",
+        "nanopop": "^2.1.0"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.17.tgz",
+      "integrity": "sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.22.tgz",
+      "integrity": "sha512-jQ0pFPmZwTEiRNSb+i9Ow/I/cHv2tXYqsnHKKyCQ08irI2kdF5qmYedmF8si8mA7zepUFmJ2hqzS8CQmNOWOkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.4",
+        "@vue/shared": "3.5.22",
+        "entities": "^4.5.0",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.22.tgz",
+      "integrity": "sha512-W8RknzUM1BLkypvdz10OVsGxnMAuSIZs9Wdx1vzA3mL5fNMN15rhrSCLiTm6blWeACwUwizzPVqGJgOGBEN/hA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.22",
+        "@vue/shared": "3.5.22"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.22.tgz",
+      "integrity": "sha512-tbTR1zKGce4Lj+JLzFXDq36K4vcSZbJ1RBu8FxcDv1IGRz//Dh2EBqksyGVypz3kXpshIfWKGOCcqpSbyGWRJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.4",
+        "@vue/compiler-core": "3.5.22",
+        "@vue/compiler-dom": "3.5.22",
+        "@vue/compiler-ssr": "3.5.22",
+        "@vue/shared": "3.5.22",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.19",
+        "postcss": "^8.5.6",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.22.tgz",
+      "integrity": "sha512-GdgyLvg4R+7T8Nk2Mlighx7XGxq/fJf9jaVofc3IL0EPesTE86cP/8DD1lT3h1JeZr2ySBvyqKQJgbS54IX1Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.22",
+        "@vue/shared": "3.5.22"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.22.tgz",
+      "integrity": "sha512-f2Wux4v/Z2pqc9+4SmgZC1p73Z53fyD90NFWXiX9AKVnVBEvLFOWCEgJD3GdGnlxPZt01PSlfmLqbLYzY/Fw4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.22"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.22.tgz",
+      "integrity": "sha512-EHo4W/eiYeAzRTN5PCextDUZ0dMs9I8mQ2Fy+OkzvRPUYQEyK9yAjbasrMCXbLNhF7P0OUyivLjIy0yc6VrLJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.22",
+        "@vue/shared": "3.5.22"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.22.tgz",
+      "integrity": "sha512-Av60jsryAkI023PlN7LsqrfPvwfxOd2yAwtReCjeuugTJTkgrksYJJstg1e12qle0NarkfhfFu1ox2D+cQotww==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.22",
+        "@vue/runtime-core": "3.5.22",
+        "@vue/shared": "3.5.22",
+        "csstype": "^3.1.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.22.tgz",
+      "integrity": "sha512-gXjo+ao0oHYTSswF+a3KRHZ1WszxIqO7u6XwNHqcqb9JfyIL/pbWrrh/xLv7jeDqla9u+LK7yfZKHih1e1RKAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.22",
+        "@vue/shared": "3.5.22"
+      },
+      "peerDependencies": {
+        "vue": "3.5.22"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.22.tgz",
+      "integrity": "sha512-F4yc6palwq3TT0u+FYf0Ns4Tfl9GRFURDN2gWG7L1ecIaS/4fCIuFOjMTnCyjsu/OK6vaDKLCrGAa+KvvH+h4w==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.10.0.tgz",
+      "integrity": "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
+      "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
+      "license": "MIT"
+    },
+    "node_modules/ant-design-vue": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/ant-design-vue/-/ant-design-vue-4.2.6.tgz",
+      "integrity": "sha512-t7eX13Yj3i9+i5g9lqFyYneoIb3OzTvQjq9Tts1i+eiOd3Eva/6GagxBSXM1fOCjqemIu0FYVE1ByZ/38epR3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@ant-design/colors": "^6.0.0",
+        "@ant-design/icons-vue": "^7.0.0",
+        "@babel/runtime": "^7.10.5",
+        "@ctrl/tinycolor": "^3.5.0",
+        "@emotion/hash": "^0.9.0",
+        "@emotion/unitless": "^0.8.0",
+        "@simonwep/pickr": "~1.8.0",
+        "array-tree-filter": "^2.1.0",
+        "async-validator": "^4.0.0",
+        "csstype": "^3.1.1",
+        "dayjs": "^1.10.5",
+        "dom-align": "^1.12.1",
+        "dom-scroll-into-view": "^2.0.0",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.15",
+        "resize-observer-polyfill": "^1.5.1",
+        "scroll-into-view-if-needed": "^2.2.25",
+        "shallow-equal": "^1.0.0",
+        "stylis": "^4.1.3",
+        "throttle-debounce": "^5.0.0",
+        "vue-types": "^3.0.0",
+        "warning": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ant-design-vue"
+      },
+      "peerDependencies": {
+        "vue": ">=3.2.0"
+      }
+    },
+    "node_modules/array-tree-filter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-tree-filter/-/array-tree-filter-2.1.0.tgz",
+      "integrity": "sha512-4ROwICNlNw/Hqa9v+rk5h22KjmzB1JGTMVKP2AKJBOCgb0yL0ASf0+YvCcLNNwquOHNX48jkeZIJ3a+oOQqKcw==",
+      "license": "MIT"
+    },
+    "node_modules/async-validator": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/async-validator/-/async-validator-4.2.5.tgz",
+      "integrity": "sha512-7HhHjtERjqlNbZtqNqy2rckN/SpOOlmDliet+lP7k+eKZEjPk3DgyeU9lIXLdeLz0uBbbVp+9Qdow9wJWgwwfg==",
+      "license": "MIT"
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/compute-scroll-into-view": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.20.tgz",
+      "integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg==",
+      "license": "MIT"
+    },
+    "node_modules/core-js": {
+      "version": "3.45.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.45.1.tgz",
+      "integrity": "sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.18",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.18.tgz",
+      "integrity": "sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==",
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "bin": {
+        "detect-libc": "bin/detect-libc.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/dom-align": {
+      "version": "1.12.4",
+      "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.12.4.tgz",
+      "integrity": "sha512-R8LUSEay/68zE5c8/3BDxiTEvgb4xZTF0RKmAHfiEVN3klfIpXfi2/QCoiWPccVQ0J/ZGdz9OjzL4uJEP/MRAw==",
+      "license": "MIT"
+    },
+    "node_modules/dom-scroll-into-view": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/dom-scroll-into-view/-/dom-scroll-into-view-2.0.1.tgz",
+      "integrity": "sha512-bvVTQe1lfaUr1oFzZX80ce9KLDlZ3iU+XGNE/bz9HnGdklTieqsbmsLHe+rT2XWqopvL0PckkYqN7ksmm5pe3w==",
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/immutable": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.3.tgz",
+      "integrity": "sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.1.tgz",
+      "integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nanopop": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/nanopop/-/nanopop-2.4.2.tgz",
+      "integrity": "sha512-NzOgmMQ+elxxHeIha+OG/Pv3Oc3p4RU2aBhwWwAqDpXrdTbtRylbRLQztLy8dMMwfl6pclznBdfUhccEn9ZIzw==",
+      "license": "MIT"
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pinia": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.3.1.tgz",
+      "integrity": "sha512-khUlZSwt9xXCaTbbxFYBKDc/bWAGWJjOgvxETwkTN7KRm66EeT1ZdZj6i2ceh9sP2Pzqsbc704r2yngBrxBVug==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.3",
+        "vue-demi": "^0.14.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.4.4",
+        "vue": "^2.7.0 || ^3.5.11"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.2.tgz",
+      "integrity": "sha512-I25/2QgoROE1vYV+NQ1En9T9UFB9Cmfm2CJ83zZOlaDpvz29wGQSZXWKw7MiNXau7wYgB/T9fVIdIuEQ+KbiiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.2",
+        "@rollup/rollup-android-arm64": "4.52.2",
+        "@rollup/rollup-darwin-arm64": "4.52.2",
+        "@rollup/rollup-darwin-x64": "4.52.2",
+        "@rollup/rollup-freebsd-arm64": "4.52.2",
+        "@rollup/rollup-freebsd-x64": "4.52.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.2",
+        "@rollup/rollup-linux-arm64-musl": "4.52.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.2",
+        "@rollup/rollup-linux-x64-gnu": "4.52.2",
+        "@rollup/rollup-linux-x64-musl": "4.52.2",
+        "@rollup/rollup-openharmony-arm64": "4.52.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.2",
+        "@rollup/rollup-win32-x64-gnu": "4.52.2",
+        "@rollup/rollup-win32-x64-msvc": "4.52.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/sass": {
+      "version": "1.93.2",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.93.2.tgz",
+      "integrity": "sha512-t+YPtOQHpGW1QWsh1CHQ5cPIr9lbbGZLZnbihP/D/qZj/yuV68m8qarcV17nvkOX81BCrvzAlq2klCQFZghyTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^4.0.0",
+        "immutable": "^5.0.2",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher": "^2.4.1"
+      }
+    },
+    "node_modules/scroll-into-view-if-needed": {
+      "version": "2.2.31",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.31.tgz",
+      "integrity": "sha512-dGCXy99wZQivjmjIqihaBQNjryrz5rueJY7eHfTdyWEiR4ttYpsajb14rn9s5d4DY4EcY6+4+U/maARBXJedkA==",
+      "license": "MIT",
+      "dependencies": {
+        "compute-scroll-into-view": "^1.0.20"
+      }
+    },
+    "node_modules/shallow-equal": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
+      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==",
+      "license": "MIT"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stylis": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+      "license": "MIT"
+    },
+    "node_modules/throttle-debounce": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.2.tgz",
+      "integrity": "sha512-B71/4oyj61iNH0KeCamLuE2rmKuTO5byTOSVwECM5FA7TiAiAW+UqTKZ9ERueC4qvgSttUhdmq1mXC3kJqGX7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.22"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.20",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.22.tgz",
+      "integrity": "sha512-toaZjQ3a/G/mYaLSbV+QsQhIdMo9x5rrqIpYRObsJ6T/J+RyCSFwN2LHNVH9v8uIcljDNa3QzPVdv3Y6b9hAJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.22",
+        "@vue/compiler-sfc": "3.5.22",
+        "@vue/runtime-dom": "3.5.22",
+        "@vue/server-renderer": "3.5.22",
+        "@vue/shared": "3.5.22"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-i18n": {
+      "version": "9.14.5",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.14.5.tgz",
+      "integrity": "sha512-0jQ9Em3ymWngyiIkj0+c/k7WgaPO+TNzjKSNq9BvBQaKJECqn9cd9fL4tkDhB5G1QBskGl9YxxbDAhgbFtpe2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/core-base": "9.14.5",
+        "@intlify/shared": "9.14.5",
+        "@vue/devtools-api": "^6.5.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
+      }
+    },
+    "node_modules/vue-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/vue-types/-/vue-types-3.0.2.tgz",
+      "integrity": "sha512-IwUC0Aq2zwaXqy74h4WCvFCUtoV0iSWr0snWnE9TnU18S66GAQyqQbRf2qfJtUuiFsBf6qp0MEwdonlwznlcrw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "3.0.1"
+      },
+      "engines": {
+        "node": ">=10.15.0"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "flashagent-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@ant-design/icons-vue": "^7.0.1",
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/xterm": "^5.3.0",
+    "ant-design-vue": "^4.2.1",
+    "highlight.js": "^11.9.0",
+    "mitt": "^3.0.1",
+    "pinia": "^2.1.7",
+    "vue": "^3.4.21",
+    "vue-i18n": "^9.13.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.7",
+    "@vitejs/plugin-vue": "^5.0.4",
+    "sass": "^1.70.0",
+    "typescript": "^5.4.2",
+    "vite": "^5.2.0"
+  }
+}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,0 +1,124 @@
+<template>
+  <a-layout class="app-layout">
+    <a-layout-header class="app-header">FlashAgent Workspace</a-layout-header>
+    <a-layout-content class="app-content">
+      <div class="content-grid">
+        <section class="server-panel">
+          <ServerManager />
+        </section>
+        <section class="workspace-panel">
+          <a-row :gutter="[16, 16]">
+            <a-col :xs="24" :md="12">
+              <SearchResultList :search-results="searchResults" />
+            </a-col>
+            <a-col :xs="24" :md="12">
+              <ImageDisplay :content="imageContent" />
+            </a-col>
+          </a-row>
+          <a-row :gutter="[16, 16]" class="terminal-row">
+            <a-col :span="24">
+              <TerminalConsole />
+            </a-col>
+          </a-row>
+          <VsCodeExplorer />
+        </section>
+      </div>
+    </a-layout-content>
+  </a-layout>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
+
+import ImageDisplay from './components/ImageDisplay.vue';
+import SearchResultList from './components/SearchResultList.vue';
+import ServerManager from './components/server/ServerManager.vue';
+import TerminalConsole from './components/terminal/TerminalConsole.vue';
+import VsCodeExplorer from './components/vscode/VsCodeExplorer.vue';
+import emitter from './utils/emitter';
+
+interface SearchResult {
+  title: string;
+  url: string;
+  content: string;
+}
+
+const searchResults = ref<SearchResult[]>([
+  {
+    title: 'FlashAgent Documentation',
+    url: 'https://example.com/docs',
+    content: 'Learn how to operate Browser-Use agents with Ant Design Vue dashboards.'
+  },
+  {
+    title: 'Model Context Protocol Overview',
+    url: 'https://example.com/mcp',
+    content: 'Integrate MCP services directly into the FlashAgent control plane.'
+  },
+  {
+    title: 'Playwright Integration Tips',
+    url: 'https://example.com/playwright',
+    content: 'Share CDP sessions between Browser-Use and Playwright for precision automation.'
+  }
+]);
+
+const imageContent = ref<string[]>([
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/w8AAn0B9oQgVcsAAAAASUVORK5CYII='
+]);
+
+onMounted(() => {
+  emitter.emit('terminal-visible', true);
+  emitter.emit('vscode-visible', true);
+});
+</script>
+
+<style scoped lang="scss">
+.app-layout {
+  min-height: 100vh;
+}
+
+.app-header {
+  color: #fff;
+  font-size: 20px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+}
+
+.app-content {
+  padding: 24px;
+  background-color: #f5f5f5;
+}
+
+.content-grid {
+  display: grid;
+  grid-template-columns: 420px 1fr;
+  gap: 24px;
+}
+
+.server-panel {
+  background: #fff;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.05);
+}
+
+.workspace-panel {
+  background: #fff;
+  border-radius: 8px;
+  padding: 16px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.terminal-row {
+  min-height: 280px;
+}
+
+@media (max-width: 1200px) {
+  .content-grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/frontend/src/components/ImageDisplay.vue
+++ b/frontend/src/components/ImageDisplay.vue
@@ -1,0 +1,59 @@
+<template>
+  <div class="image-container">
+    <img v-if="formattedImageData" :src="formattedImageData" alt="Displaying image" />
+    <div v-else class="image-placeholder">No image data</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+const props = defineProps({
+  content: {
+    type: Array as () => string[],
+    required: true
+  },
+  imageType: {
+    type: String,
+    default: 'image/jpeg'
+  }
+});
+
+const formattedImageData = computed(() => {
+  if (!props.content || props.content.length === 0) {
+    return '';
+  }
+  const base64Data = props.content[props.content.length - 1];
+  if (!base64Data) {
+    return '';
+  }
+  if (base64Data.startsWith('data:')) {
+    return base64Data;
+  }
+  return `data:${props.imageType};base64,${base64Data}`;
+});
+</script>
+
+<style scoped lang="scss">
+.image-container {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 200px;
+
+  img {
+    max-width: 100%;
+    height: auto;
+    object-fit: contain;
+    border: 1px solid #dadada;
+    border-radius: 4px;
+    background-color: #fff;
+  }
+
+  .image-placeholder {
+    color: #888;
+    font-size: 0.875rem;
+  }
+}
+</style>

--- a/frontend/src/components/SearchResultList.vue
+++ b/frontend/src/components/SearchResultList.vue
@@ -1,0 +1,76 @@
+<template>
+  <div class="search-result-list-container">
+    <div v-for="(result, index) in searchResults" :key="index" class="result-item">
+      <div class="header">
+        <a :href="result.url" target="_blank" rel="noreferrer">{{ result.title }}</a>
+      </div>
+      <div class="summary-container">
+        <span class="summary">{{ result.content }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+interface SearchResult {
+  title: string;
+  url: string;
+  content: string;
+}
+
+defineProps<{ searchResults: SearchResult[] }>();
+</script>
+
+<style scoped lang="scss">
+.search-result-list-container {
+  padding: 0.75rem 1rem;
+  max-height: 100%;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.search-result-list-container::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+}
+
+.result-item {
+  padding: 0.75rem 0;
+  border-bottom: 1px solid #e5e7eb;
+
+  .header {
+    display: flex;
+    align-items: center;
+    margin-bottom: 0.5rem;
+
+    a {
+      color: #34322d;
+      text-decoration: none;
+      font-size: 0.875rem;
+      line-height: 1.25rem;
+      font-weight: 500;
+      transition: color 0.3s ease;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+
+  .summary-container {
+    .summary {
+      color: #858481;
+      font-size: 0.75rem;
+      line-height: 1rem;
+      margin-top: 0.125rem;
+      word-wrap: break-word;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: -webkit-box;
+      -webkit-line-clamp: 3;
+      -webkit-box-orient: vertical;
+    }
+  }
+}
+</style>

--- a/frontend/src/components/server/ServerList.vue
+++ b/frontend/src/components/server/ServerList.vue
@@ -1,0 +1,97 @@
+<template>
+  <div class="mcp-server-menu">
+    <div v-if="!servers || servers.length === 0" class="no-servers-info">
+      {{ $t('setting.mcpService.noServersAvailable') }}
+    </div>
+    <div
+      v-else
+      v-for="server in servers"
+      :key="server.id"
+      class="menu-item"
+      :class="{ 'menu-item-selected': server.id === selectedServerId }"
+      @click="$emit('select', server)"
+    >
+      <CodeOutlined />
+      <span class="menu-item-label">{{ server.name }}</span>
+      <span
+        class="menu-item-status"
+        :class="{
+          'menu-item-status-on': server.activate,
+          'menu-item-status-off': !server.activate
+        }"
+      ></span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { CodeOutlined } from '@ant-design/icons-vue';
+
+import type { McpServer } from '@/store/modules/server';
+
+defineEmits<{
+  (event: 'select', server: McpServer): void;
+}>();
+
+defineProps<{
+  servers: McpServer[];
+  selectedServerId: string | null;
+}>();
+</script>
+
+<style scoped>
+.mcp-server-menu {
+  padding: 16px 8px;
+  height: 100%;
+}
+
+.no-servers-info {
+  padding: 20px;
+  text-align: center;
+  color: #888;
+}
+
+.menu-item {
+  display: flex;
+  align-items: center;
+  padding: 12px;
+  cursor: pointer;
+  font-size: 14px;
+  border-radius: 4px;
+  margin-bottom: 8px;
+}
+
+.menu-item:hover {
+  background: #f0f0f0;
+}
+
+.menu-item-label {
+  margin-left: 10px;
+  font-size: 14px;
+  flex-grow: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.menu-item-status {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-left: 16px;
+  flex-shrink: 0;
+}
+
+.menu-item-status-on {
+  background-color: #52c41a;
+}
+
+.menu-item-status-off {
+  background-color: #d9d9d9;
+}
+
+.menu-item-selected {
+  background-color: #e6f7ff;
+  color: #1890ff;
+}
+</style>

--- a/frontend/src/components/server/ServerManager.vue
+++ b/frontend/src/components/server/ServerManager.vue
@@ -1,0 +1,302 @@
+<template>
+  <div class="mcp-manager-container">
+    <div class="top-action-bar">
+      <h2 class="title">{{ $t('setting.mcpService.title') }}</h2>
+      <div class="actions">
+        <a-button @click="showImportModal">
+          <template #icon>
+            <ImportOutlined />
+          </template>
+          {{ $t('setting.mcpService.importFromJson') }}
+        </a-button>
+        <a-button type="primary" @click="handleAddServer" style="margin-left: 8px">
+          <template #icon>
+            <PlusOutlined />
+          </template>
+          {{ $t('setting.mcpService.addMcpServer') }}
+        </a-button>
+      </div>
+    </div>
+
+    <div class="main-content">
+      <div class="server-list-panel">
+        <ServerList :servers="mcpServerList" :selectedServerId="chooseMCPServer?.id ?? null" @select="handleMcpServer" />
+      </div>
+      <div class="server-settings-panel">
+        <template v-if="chooseMCPServer">
+          <ServerSettings :server="chooseMCPServer" @update:server="handleUpdateServer" @save="handleMCPServerSave" @delete="handleMCPServerDelete" />
+        </template>
+        <div v-else class="no-server-placeholder">
+          <div class="placeholder-content">
+            <div class="placeholder-icon">
+              <CodeOutlined />
+            </div>
+            <p class="placeholder-text">{{ $t('setting.mcpService.noServerSelected') }}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <a-modal v-model:visible="importModalVisible" :title="$t('setting.mcpService.importModalTitle')" @ok="handleImportOk" :ok-text="$t('setting.mcpService.ok')" :cancel-text="$t('setting.mcpService.cancel')">
+      <pre>{{ exampleJson }}</pre>
+      <a-textarea v-model:value="importJsonText" :rows="10" :placeholder="$t('setting.mcpService.importJson')" />
+    </a-modal>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue';
+import { storeToRefs } from 'pinia';
+import { message } from 'ant-design-vue';
+import { PlusOutlined, CodeOutlined, ImportOutlined } from '@ant-design/icons-vue';
+import { useI18n } from 'vue-i18n';
+
+import ServerList from './ServerList.vue';
+import ServerSettings from './ServerSettings.vue';
+import { useServerStore, type McpServer } from '@/store/modules/server';
+
+const { t } = useI18n();
+const serverStore = useServerStore();
+const { servers: mcpServerList } = storeToRefs(serverStore);
+const { addServer, updateServer, deleteServer, fetchServers } = serverStore;
+
+const chooseMCPServer = ref<McpServer | null>(null);
+const importModalVisible = ref(false);
+const importJsonText = ref('');
+
+const exampleServer = {
+  mcpServers: {
+    'amap-amap-sse': {
+      url: 'https://mcp.amap.com/sse?key=amap_key'
+    }
+  }
+};
+
+const exampleJson = computed(() => JSON.stringify(exampleServer, null, 2));
+
+const handleMcpServer = (server: McpServer) => {
+  chooseMCPServer.value = server;
+};
+
+const handleUpdateServer = (server: McpServer) => {
+  if (!chooseMCPServer.value) {
+    chooseMCPServer.value = server;
+  } else {
+    chooseMCPServer.value = { ...chooseMCPServer.value, ...server };
+  }
+};
+
+const handleMCPServerSave = () => {
+  if (chooseMCPServer.value) {
+    updateServer(chooseMCPServer.value);
+  }
+};
+
+const handleMCPServerDelete = (serverId: string) => {
+  deleteServer(serverId);
+};
+
+const handleAddServer = () => {
+  const newServer: Omit<McpServer, 'id'> = {
+    name: 'MCP Server',
+    description: '',
+    activate: false,
+    type: 'stdio',
+    command: '',
+    registryUrl: '',
+    url: '',
+    args: [],
+    env: {}
+  };
+  addServer(newServer);
+};
+
+const showImportModal = () => {
+  importModalVisible.value = true;
+  importJsonText.value = '';
+};
+
+const resolveMcpServerType = (server: Partial<McpServer>) => {
+  const { url = '', command = '' } = server;
+  if (url.includes('sse')) {
+    return 'sse' as const;
+  }
+  if (command.startsWith('npx') || command.startsWith('uv')) {
+    return 'stdio' as const;
+  }
+  if (url.includes('mcp')) {
+    return 'streamableHttp' as const;
+  }
+  return 'stdio' as const;
+};
+
+const handleImportOk = () => {
+  try {
+    const importData = JSON.parse(importJsonText.value);
+
+    if (importData.mcpServers) {
+      const servers = importData.mcpServers;
+      let serversAddedCount = 0;
+      for (const serverName in servers) {
+        if (Object.prototype.hasOwnProperty.call(servers, serverName)) {
+          const serverConfig = servers[serverName];
+          const type = resolveMcpServerType(serverConfig);
+
+          const newServer: Omit<McpServer, 'id'> = {
+            name: serverName,
+            description: serverConfig.description || '',
+            activate: false,
+            url: serverConfig.url || '',
+            type,
+            command: type === 'stdio' ? serverConfig.command ?? '' : '',
+            registryUrl: serverConfig.registryUrl || '',
+            args: serverConfig.args || [],
+            env: serverConfig.env || {}
+          };
+          addServer(newServer);
+          serversAddedCount++;
+        }
+      }
+
+      if (serversAddedCount > 0) {
+        message.success(t('mcpService.importSuccess', { count: serversAddedCount }));
+      } else {
+        message.warn(t('mcpService.noValidServer'));
+      }
+    } else {
+      if (!importData.name) {
+        message.error(t('mcpService.invalidJson'));
+        return;
+      }
+      const type = resolveMcpServerType(importData);
+      const newServer: Omit<McpServer, 'id'> = {
+        name: importData.name,
+        description: importData.description || '',
+        activate: false,
+        url: importData.url || '',
+        type,
+        command: type === 'stdio' ? importData.command ?? '' : '',
+        registryUrl: importData.registryUrl || '',
+        args: importData.args || [],
+        env: importData.env || {}
+      };
+      addServer(newServer);
+      message.success(t('mcpService.importSuccessSingle'));
+    }
+
+    importModalVisible.value = false;
+  } catch (e) {
+    message.error(t('mcpService.invalidJson'));
+    console.error('JSON parsing error:', e);
+  }
+};
+
+watch(
+  () => [...mcpServerList.value],
+  (newServers, oldServers = []) => {
+    if (newServers.length > oldServers.length) {
+      const addedServer = newServers.find((ns) => !oldServers.some((os) => os.id === ns.id));
+      if (addedServer) {
+        chooseMCPServer.value = addedServer;
+        return;
+      }
+    }
+
+    const selectedServerExists =
+      !!chooseMCPServer.value && newServers.some((s) => s.id === chooseMCPServer.value?.id);
+    if (!selectedServerExists) {
+      chooseMCPServer.value = newServers[0] || null;
+    }
+  },
+  { deep: true }
+);
+
+onMounted(() => {
+  fetchServers();
+  if (mcpServerList.value.length === 0) {
+    handleAddServer();
+  } else {
+    chooseMCPServer.value = mcpServerList.value[0] ?? null;
+  }
+});
+</script>
+
+<style scoped lang="scss">
+.mcp-manager-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background-color: #f0f2f5;
+}
+
+.top-action-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 24px;
+  background-color: #fff;
+  border-bottom: 1px solid #e8e8e8;
+
+  .title {
+    font-size: 20px;
+    font-weight: 500;
+    margin: 0;
+  }
+}
+
+.main-content {
+  display: flex;
+  flex-grow: 1;
+  overflow: hidden;
+  padding: 24px;
+  gap: 24px;
+}
+
+.server-list-panel {
+  width: 280px;
+  flex-shrink: 0;
+  background: #fff;
+  border-radius: 8px;
+  overflow-y: auto;
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.03);
+}
+
+.server-settings-panel {
+  flex-grow: 1;
+  background: #fff;
+  border-radius: 8px;
+  overflow-y: auto;
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.03);
+}
+
+.no-server-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  padding: 50px;
+
+  .placeholder-content {
+    text-align: center;
+    color: rgba(0, 0, 0, 0.25);
+
+    .placeholder-icon {
+      font-size: 48px;
+      margin-bottom: 16px;
+    }
+
+    .placeholder-text {
+      font-size: 16px;
+      margin: 0;
+    }
+  }
+}
+
+pre {
+  background-color: #f5f5f5;
+  padding: 10px;
+  border-radius: 4px;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+</style>

--- a/frontend/src/components/server/ServerSettings.vue
+++ b/frontend/src/components/server/ServerSettings.vue
@@ -1,0 +1,246 @@
+<template>
+  <div class="mcp-server-content" v-if="server">
+    <div class="mcp-server-content-header">
+      <div class="header-left">
+        <span class="mcp-server-content-header-title">{{ server.name }}</span>
+        <DeleteOutlined class="mcp-server-content-header-delete-button" @click="showDeleteConfirm(server.id)" />
+      </div>
+      <div class="header-right">
+        <a-switch v-model:checked="server.activate" class="mcp-server-content-header-activate-switch" :loading="loading" @change="handleActivateChange" />
+        <div class="mcp-server-content-header-save-button-container">
+          <a-button type="primary" @click="$emit('save')" class="mcp-server-content-header-save-button">
+            <SaveOutlined />
+            {{ $t('setting.mcpService.save') }}
+          </a-button>
+        </div>
+      </div>
+    </div>
+
+    <div class="mcp-server-content-main">
+      <div class="mcp-server-content-main-name mcp-server-content-main-item">
+        <span>{{ $t('setting.mcpService.name') }}</span>
+        <a-input v-model:value="server.name" :placeholder="$t('setting.mcpService.namePlaceholder')" class="text-item input" />
+      </div>
+      <div class="mcp-server-content-main-description mcp-server-content-main-item">
+        <span>{{ $t('setting.mcpService.description') }}</span>
+        <a-textarea v-model:value="server.description" :rows="4" :placeholder="$t('setting.mcpService.descriptionPlaceholder')" class="text-item" />
+      </div>
+      <div class="mcp-server-content-main-type mcp-server-content-main-item">
+        <span>{{ $t('setting.mcpService.type') }}</span>
+        <a-radio-group v-model:value="server.type" name="radioGroup" class="input radio">
+          <a-radio value="stdio">{{ $t('setting.mcpService.stdio') }}</a-radio>
+          <a-radio value="sse">{{ $t('setting.mcpService.sse') }}</a-radio>
+          <a-radio value="streamableHttp">{{ $t('setting.mcpService.streamableHttp') }}</a-radio>
+        </a-radio-group>
+      </div>
+      <div class="mcp-server-content-main-command mcp-server-content-main-item" v-if="server.type === 'stdio'">
+        <span>{{ $t('setting.mcpService.command') }}</span>
+        <a-input v-model:value="server.command" :placeholder="$t('setting.mcpService.commandPlaceholder')" class="text-item input" />
+      </div>
+      <div class="mcp-server-content-main-url mcp-server-content-main-item" v-if="server.type === 'sse' || server.type === 'streamableHttp'">
+        <span>{{ $t('setting.mcpService.url') }}</span>
+        <a-input
+          v-model:value="server.url"
+          :placeholder="$t('setting.mcpService.url')"
+          class="text-item input"
+          @update:value="handleUpdateServer({ url: $event })"
+        />
+      </div>
+      <div class="mcp-server-content-main-args mcp-server-content-main-item">
+        <span>{{ $t('setting.mcpService.args') }}</span>
+        <a-textarea v-model:value="argsText" :rows="4" :placeholder="$t('setting.mcpService.argsPlaceholder')" class="text-item" @update:value="handleArgsChange" />
+      </div>
+      <div class="mcp-server-content-main-env mcp-server-content-main-item">
+        <span>{{ $t('setting.mcpService.env') }}</span>
+        <a-textarea v-model:value="envText" :rows="4" :placeholder="$t('setting.mcpService.envPlaceholder')" class="text-item" @update:value="handleEnvChange" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { DeleteOutlined, SaveOutlined, ExclamationCircleOutlined } from '@ant-design/icons-vue';
+import { message, Modal } from 'ant-design-vue';
+import { h, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import type { McpServer } from '@/store/modules/server';
+import * as mcpService from '@/services/mcp';
+
+const emit = defineEmits<{
+  (event: 'update:server', server: McpServer): void;
+  (event: 'save'): void;
+  (event: 'delete', serverId: string): void;
+}>();
+
+const props = defineProps<{ server: McpServer }>();
+
+const { t } = useI18n();
+const argsText = ref('');
+const envText = ref('');
+const loading = ref(false);
+
+const validateServerConnection = async () => {
+  try {
+    loading.value = true;
+    const result = await mcpService.connect(props.server);
+    return result.ok;
+  } catch (error: unknown) {
+    const err = error as Error;
+    message.error(err.message || t('mcpService.connectionFailed'));
+    return false;
+  } finally {
+    loading.value = false;
+  }
+};
+
+const updateServer = (data: Partial<McpServer>) => {
+  emit('update:server', { ...props.server, ...data });
+};
+
+const handleActivateChange = async (checked: boolean) => {
+  if (checked) {
+    const isValid = await validateServerConnection();
+    if (!isValid) {
+      message.error(t('mcpService.connectionFailed'));
+      updateServer({ activate: false });
+      return;
+    }
+  }
+  updateServer({ activate: checked });
+  emit('save');
+};
+
+const handleArgsChange = (value: string) => {
+  const args = value
+    .split('\n')
+    .map((arg) => arg.trim())
+    .filter(Boolean);
+  updateServer({ args });
+};
+
+const handleEnvChange = (value: string) => {
+  const envEntries = value
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.split('='));
+
+  const env: Record<string, string> = {};
+  envEntries.forEach(([key, ...rest]) => {
+    const trimmedKey = key?.trim();
+    const trimmedValue = rest.join('=').trim();
+    if (trimmedKey && trimmedValue) {
+      env[trimmedKey] = trimmedValue;
+    }
+  });
+  updateServer({ env });
+};
+
+const formatArgsText = (args: string[]) => args.join('\n');
+
+const formatEnvText = (env: Record<string, string>) =>
+  Object.entries(env)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('\n');
+
+const showDeleteConfirm = (serverId: string) => {
+  Modal.confirm({
+    title: t('setting.mcpService.deleteConfirmTitle'),
+    icon: () => h(ExclamationCircleOutlined, { style: 'color: #ff4d4f' }),
+    content: t('setting.mcpService.deleteConfirmContent'),
+    okText: t('common.yes'),
+    okType: 'danger',
+    cancelText: t('common.cancel'),
+    onOk() {
+      emit('delete', serverId);
+    }
+  });
+};
+
+const handleUpdateServer = (data: Partial<McpServer>) => {
+  updateServer(data);
+};
+
+watch(
+  () => props.server,
+  (newServer) => {
+    argsText.value = formatArgsText(newServer.args || []);
+    envText.value = formatEnvText(newServer.env || {});
+  },
+  { immediate: true, deep: true }
+);
+</script>
+
+<style scoped>
+.mcp-server-content {
+  flex: 1;
+  padding: 16px;
+  overflow-y: auto;
+}
+
+.mcp-server-content-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px;
+  background: white;
+  border-radius: 8px;
+  margin-bottom: 16px;
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.03);
+}
+
+.header-left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.header-right {
+  display: flex;
+  align-items: center;
+}
+
+.mcp-server-content-header-title {
+  font-size: 16px;
+  font-weight: 500;
+  margin-right: 16px;
+}
+
+.mcp-server-content-header-delete-button {
+  color: #ff4d4f;
+  font-size: 16px;
+  cursor: pointer;
+}
+
+.mcp-server-content-header-save-button-container {
+  margin-left: 16px;
+}
+
+.mcp-server-content-main {
+  background: white;
+  border-radius: 8px;
+  padding: 24px;
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.03);
+}
+
+.mcp-server-content-main-item {
+  margin-bottom: 24px;
+}
+
+.mcp-server-content-main-item > span {
+  display: block;
+  margin-bottom: 8px;
+  font-weight: 500;
+  color: rgba(0, 0, 0, 0.85);
+}
+
+.text-item {
+  width: 100%;
+}
+
+.radio {
+  display: block;
+  line-height: 32px;
+}
+</style>

--- a/frontend/src/components/terminal/TerminalConsole.vue
+++ b/frontend/src/components/terminal/TerminalConsole.vue
@@ -1,0 +1,216 @@
+<template>
+  <div class="container" v-show="visible">
+    <div class="terminal-header">
+      <span>Command Console</span>
+      <CloseOutlined @click="visible = false" />
+    </div>
+    <div ref="terminalRef" class="terminal-container"></div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { CloseOutlined } from '@ant-design/icons-vue';
+import { FitAddon } from '@xterm/addon-fit';
+import { Terminal } from '@xterm/xterm';
+import '@xterm/xterm/css/xterm.css';
+import { onMounted, ref, watch } from 'vue';
+
+import { useChatStore } from '@/store/modules/chat';
+import emitter from '@/utils/emitter';
+
+const chatStore = useChatStore();
+
+const props = defineProps<{ content?: string | string[] }>();
+
+const terminalRef = ref<HTMLDivElement | null>(null);
+const terminal = ref<Terminal>();
+const visible = ref(false);
+let currentLine = '';
+const commandHistory: string[] = [];
+let historyIndex = -1;
+
+const writePrompt = () => {
+  terminal.value?.write('\x1b[32mflashagent@workspace:~ $ \x1b[0m');
+};
+
+const saveHistory = () => {
+  localStorage.setItem('terminalHistory', JSON.stringify(commandHistory));
+};
+
+const sendToServer = async (command: string) => {
+  chatStore.socket.emit('oh_user_action', {
+    action: 'run',
+    args: {
+      command,
+      is_input: false,
+      thought: '',
+      blocking: false,
+      hidden: false,
+      confirmation_state: 'confirmed'
+    }
+  });
+};
+
+const handleCommand = async (command: string) => {
+  switch (command.trim()) {
+    case 'help':
+      terminal.value?.writeln('Available commands:');
+      terminal.value?.writeln('  help     - Show this help message');
+      terminal.value?.writeln('  clear    - Clear the terminal');
+      terminal.value?.writeln('  history  - Show command history');
+      terminal.value?.writeln('  server   - Send command to server');
+      break;
+    case 'clear':
+      terminal.value?.clear();
+      break;
+    case 'history':
+      commandHistory.forEach((cmd, index) => {
+        terminal.value?.writeln(`${index + 1}  ${cmd}`);
+      });
+      break;
+    case '':
+      break;
+    default:
+      await sendToServer(command);
+  }
+  saveHistory();
+};
+
+const bootstrapTerminal = () => {
+  const term = new Terminal({
+    cursorBlink: true,
+    fontSize: 14,
+    fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+    theme: {
+      background: '#1e1e1e',
+      foreground: '#ffffff',
+      green: 'rgb(0, 187, 0)'
+    },
+    wordWrap: true
+  });
+
+  const addon = new FitAddon();
+  term.loadAddon(addon);
+  terminal.value = term;
+
+  term.open(terminalRef.value!);
+  addon.fit();
+
+  term.write('Welcome to the terminal!\r\n');
+  writePrompt();
+
+  window.addEventListener('resize', () => addon.fit());
+
+  term.onKey(({ key, domEvent }) => {
+    const printable = !domEvent.altKey && !domEvent.ctrlKey && !domEvent.metaKey;
+    if (domEvent.key === 'Enter') {
+      term.write('\r\n');
+      void handleCommand(currentLine);
+      if (currentLine.trim()) {
+        commandHistory.push(currentLine);
+        historyIndex = commandHistory.length;
+      }
+      currentLine = '';
+      writePrompt();
+    } else if (domEvent.key === 'Backspace') {
+      if (currentLine.length > 0) {
+        currentLine = currentLine.slice(0, -1);
+        term.write('\b \b');
+      }
+    } else if (domEvent.key === 'ArrowUp') {
+      if (historyIndex > 0) {
+        historyIndex--;
+        currentLine = commandHistory[historyIndex];
+        term.write(`\r\x1b[K`);
+        writePrompt();
+        term.write(currentLine);
+      }
+    } else if (domEvent.key === 'ArrowDown') {
+      if (historyIndex < commandHistory.length - 1) {
+        historyIndex++;
+        currentLine = commandHistory[historyIndex];
+      } else {
+        historyIndex = commandHistory.length;
+        currentLine = '';
+      }
+      term.write(`\r\x1b[K`);
+      writePrompt();
+      term.write(currentLine);
+    } else if (printable) {
+      currentLine += key;
+      term.write(key);
+    }
+  });
+};
+
+watch(
+  () => props.content,
+  (newVal) => {
+    if (!terminal.value) {
+      return;
+    }
+
+    terminal.value.clear();
+    if (Array.isArray(newVal)) {
+      newVal.forEach((line) => terminal.value?.writeln(line));
+    } else if (typeof newVal === 'string' && newVal) {
+      terminal.value.writeln(newVal);
+    }
+    terminal.value.writeln('');
+    writePrompt();
+  }
+);
+
+onMounted(() => {
+  bootstrapTerminal();
+
+  emitter.on('terminal-visible', (value) => {
+    visible.value = value;
+    if (value) {
+      terminal.value?.focus();
+    }
+  });
+
+  emitter.on('terminal', (payload) => {
+    if (!terminal.value) return;
+    if (payload.type === 'command') {
+      terminal.value.writeln(payload.content);
+    } else if (payload.type === 'observation') {
+      terminal.value.writeln(`${payload.content}\n`);
+      writePrompt();
+    }
+  });
+});
+</script>
+
+<style scoped lang="scss">
+.container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  margin: 20px;
+  border-radius: 12px;
+  background-color: #1e1e1e;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+}
+
+.terminal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  background-color: #2d2d2d;
+  color: #fff;
+  cursor: pointer;
+  user-select: none;
+  border-bottom: 1px solid #3d3d3d;
+}
+
+.terminal-container {
+  display: flex;
+  flex: 1;
+  width: 100%;
+  padding: 10px;
+}
+</style>

--- a/frontend/src/components/terminal/TerminalPreview.vue
+++ b/frontend/src/components/terminal/TerminalPreview.vue
@@ -1,0 +1,101 @@
+<template>
+  <div class="container">
+    <div ref="terminalRef" class="terminal-container"></div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
+import { Terminal } from '@xterm/xterm';
+import '@xterm/xterm/css/xterm.css';
+
+import emitter from '@/utils/emitter';
+
+const terminalRef = ref<HTMLDivElement | null>(null);
+const terminal = ref<Terminal>();
+let currentLine = '';
+const commandHistory: string[] = [];
+let historyIndex = -1;
+
+const writePrompt = () => {
+  terminal.value?.write('\n$ ');
+};
+
+const handleCommand = async (command: string) => {
+  switch (command.trim()) {
+    case 'clear':
+      terminal.value?.clear();
+      break;
+    case 'history':
+      commandHistory.forEach((cmd, index) => terminal.value?.writeln(`${index + 1}  ${cmd}`));
+      break;
+    default:
+      emitter.emit('terminal', { type: 'command', content: command });
+  }
+};
+
+onMounted(() => {
+  const term = new Terminal({
+    cursorBlink: true,
+    fontSize: 14,
+    fontFamily: 'Menlo, Monaco, "Courier New", monospace'
+  });
+  terminal.value = term;
+  term.open(terminalRef.value!);
+  writePrompt();
+
+  term.onKey(({ key, domEvent }) => {
+    const printable = !domEvent.altKey && !domEvent.ctrlKey && !domEvent.metaKey;
+    if (domEvent.key === 'Enter') {
+      term.write('\r\n');
+      void handleCommand(currentLine);
+      if (currentLine.trim()) {
+        commandHistory.push(currentLine);
+        historyIndex = commandHistory.length;
+      }
+      currentLine = '';
+      writePrompt();
+    } else if (domEvent.key === 'Backspace') {
+      if (currentLine.length > 0) {
+        currentLine = currentLine.slice(0, -1);
+        term.write('\b \b');
+      }
+    } else if (domEvent.key === 'ArrowUp') {
+      if (historyIndex > 0) {
+        historyIndex--;
+        currentLine = commandHistory[historyIndex];
+        term.write('\r\x1b[K$ ' + currentLine);
+      }
+    } else if (domEvent.key === 'ArrowDown') {
+      if (historyIndex < commandHistory.length - 1) {
+        historyIndex++;
+        currentLine = commandHistory[historyIndex];
+        term.write('\r\x1b[K$ ' + currentLine);
+      } else {
+        historyIndex = commandHistory.length;
+        currentLine = '';
+        term.write('\r\x1b[K$ ');
+      }
+    } else if (printable) {
+      currentLine += key;
+      term.write(key);
+    }
+  });
+});
+</script>
+
+<style scoped lang="scss">
+.container {
+  display: flex;
+  margin: 10px;
+  overflow: hidden;
+}
+
+.terminal-container {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  transition: height 0.3s ease;
+  overflow: hidden;
+}
+</style>

--- a/frontend/src/components/vscode/FileTree.vue
+++ b/frontend/src/components/vscode/FileTree.vue
@@ -1,0 +1,142 @@
+<template>
+  <div class="files-container">
+    <div class="file-tree-container">
+      <div v-for="item in items" :key="item" class="file-item">
+        <div :class="['file-entry', { 'is-directory': isDirectory(item) }]" @click.stop="handleClick(item)">
+          <span class="file-icon">{{ getFileIcon(item) }}</span>
+          <span class="file-name">{{ getFileName(item) }}</span>
+        </div>
+        <div v-if="isDirectory(item) && expandedDirs[fullPath(item)]" class="subdirectory">
+          <FileTree
+            :items="subDirectories[fullPath(item)] || []"
+            :base-path="fullPath(item)"
+            :conversation-id="conversationId"
+            @item-click="$emit('item-click', $event)"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { reactive } from 'vue';
+
+import * as service from '@/services/workspace';
+import emitter from '@/utils/emitter';
+
+const props = defineProps({
+  items: {
+    type: Array as () => string[],
+    default: () => []
+  },
+  basePath: {
+    type: String,
+    default: ''
+  },
+  conversationId: {
+    type: String,
+    required: true
+  }
+});
+
+const expandedDirs = reactive<Record<string, boolean>>({});
+const subDirectories = reactive<Record<string, string[]>>({});
+
+function isDirectory(path: string) {
+  return path.endsWith('/');
+}
+
+function getFileName(path: string) {
+  const cleanPath = path.replace(/\/$/, '');
+  const parts = cleanPath.split('/');
+  return parts[parts.length - 1] || cleanPath;
+}
+
+function fullPath(item: string) {
+  return item;
+}
+
+function getFileIcon(path: string) {
+  if (isDirectory(path)) {
+    return expandedDirs[fullPath(path)] ? '📂' : '📁';
+  }
+  const extension = path.split('.').pop()?.toLowerCase();
+  switch (extension) {
+    case 'js':
+      return '📜';
+    case 'vue':
+      return '🟢';
+    case 'html':
+      return '🌐';
+    case 'css':
+      return '🎨';
+    case 'json':
+      return '⚙️';
+    case 'md':
+      return '📝';
+    default:
+      return '📄';
+  }
+}
+
+async function handleClick(item: string) {
+  const path = fullPath(item);
+  if (isDirectory(item)) {
+    if (!expandedDirs[path]) {
+      expandedDirs[path] = true;
+      await loadSubDirectory(path);
+    } else {
+      expandedDirs[path] = false;
+    }
+  } else {
+    emitter.emit('file-path', path);
+    emit('item-click', path);
+  }
+}
+
+async function loadSubDirectory(dirPath: string) {
+  if (dirPath in subDirectories) {
+    return;
+  }
+  const result = await service.getFiles(props.conversationId, dirPath);
+  subDirectories[dirPath] = Array.isArray(result) ? result : [];
+}
+
+const emit = defineEmits<{
+  (event: 'item-click', path: string): void;
+}>();
+</script>
+
+<style scoped>
+.files-container {
+  display: flex;
+  flex-direction: column;
+}
+
+.file-entry {
+  display: flex;
+  align-items: center;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  padding: 4px 6px;
+}
+
+.file-entry:hover {
+  background-color: #646464;
+  color: #fff;
+}
+
+.file-icon {
+  margin-right: 6px;
+  width: 16px;
+  text-align: center;
+}
+
+.subdirectory {
+  margin-left: 16px;
+  border-left: 1px dashed #ccc;
+  padding-left: 8px;
+}
+</style>

--- a/frontend/src/components/vscode/VsCodeExplorer.vue
+++ b/frontend/src/components/vscode/VsCodeExplorer.vue
@@ -1,0 +1,192 @@
+<template>
+  <div class="vscode-container" v-show="visible">
+    <div class="vscode-header">
+      <span>File Explorer</span>
+      <CloseOutlined @click="visible = false" />
+    </div>
+    <div class="vscode-explorer">
+      <div class="file-list">
+        <FileTree class="file-menu" :items="files" :conversation-id="conversationId" @item-click="handleFileClick" />
+        <div class="vscode-show">
+          <a-button class="vscode-button" type="primary" @click="handleOpenVsCode">
+            <template #icon>
+              <AlignLeftOutlined />
+            </template>
+            Open in VSCode
+          </a-button>
+        </div>
+      </div>
+      <div class="file-content">
+        <pre><code :class="codeLanguage" v-html="highlightedCode"></code></pre>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { AlignLeftOutlined, CloseOutlined } from '@ant-design/icons-vue';
+import hljs from 'highlight.js';
+import 'highlight.js/styles/vs2015.css';
+import { onMounted, ref } from 'vue';
+
+import FileTree from './FileTree.vue';
+import emitter from '@/utils/emitter';
+import * as workspaceService from '@/services/workspace';
+import { useChatStore } from '@/store/modules/chat';
+
+const chatStore = useChatStore();
+const conversationId = ref(chatStore.conversationId);
+const files = ref<string[]>([]);
+const visible = ref(false);
+const vscodeUrl = ref('');
+const highlightedCode = ref('');
+const codeLanguage = ref('');
+
+function getLanguageFromPath(path: string) {
+  const ext = path.split('.').pop()?.toLowerCase();
+  const map: Record<string, string> = {
+    js: 'javascript',
+    jsx: 'javascript',
+    ts: 'typescript',
+    tsx: 'typescript',
+    html: 'html',
+    css: 'css',
+    scss: 'scss',
+    less: 'less',
+    json: 'json',
+    md: 'markdown',
+    py: 'python',
+    java: 'java',
+    cpp: 'cpp',
+    c: 'c',
+    go: 'go',
+    rs: 'rust',
+    sh: 'bash',
+    yaml: 'yaml',
+    yml: 'yaml',
+    xml: 'xml',
+    sql: 'sql',
+    php: 'php',
+    rb: 'ruby',
+    kt: 'kotlin',
+    swift: 'swift',
+    dart: 'dart',
+    vue: 'javascript'
+  };
+  return map[ext ?? ''] || 'plaintext';
+}
+
+async function loadRootFiles() {
+  const result = await workspaceService.getFiles(conversationId.value, '');
+  files.value = Array.isArray(result) ? result : [];
+}
+
+const handleOpenVsCode = () => {
+  if (vscodeUrl.value) {
+    window.open(vscodeUrl.value, '_blank');
+  }
+};
+
+const handleFileClick = async (path: string) => {
+  const response = await workspaceService.getFile(conversationId.value, path);
+  codeLanguage.value = getLanguageFromPath(path);
+  try {
+    highlightedCode.value = hljs.highlight(response.code, { language: codeLanguage.value }).value;
+  } catch (error) {
+    console.error('Highlighting failed', error);
+    highlightedCode.value = response.code;
+  }
+};
+
+emitter.on('vscode-visible', (value) => {
+  visible.value = value;
+  if (value) {
+    void refreshExplorer();
+  }
+});
+
+emitter.on('file-path', (path) => {
+  void handleFileClick(path);
+});
+
+async function refreshExplorer() {
+  await loadRootFiles();
+  const { vscode_url } = await workspaceService.getVsCodeUrl(conversationId.value);
+  vscodeUrl.value = vscode_url;
+}
+
+onMounted(async () => {
+  await refreshExplorer();
+});
+</script>
+
+<style scoped>
+.vscode-container {
+  flex: 2;
+  height: 100%;
+  width: 100%;
+  margin-bottom: 20px;
+}
+
+.vscode-header {
+  margin: 15px;
+  padding: 5px;
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+  border-radius: 5px;
+  background-color: #595959;
+  color: #fff;
+}
+
+.vscode-explorer {
+  display: flex;
+  flex-direction: row;
+  margin-bottom: 10px;
+  background-color: #dbdbdb;
+  margin: 15px;
+  border-radius: 5px;
+  padding: 5px;
+  height: calc(100% - 60px);
+}
+
+.file-list {
+  display: flex;
+  flex-direction: column;
+  width: 220px;
+  background-color: #c9c9c9;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.file-content {
+  flex: 1;
+  background-color: #ffffff;
+  padding: 10px;
+  border-radius: 5px;
+  overflow: auto;
+  margin-left: 12px;
+}
+
+.file-content pre {
+  margin: 0;
+}
+
+.file-content code {
+  font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+  font-size: 14px;
+  line-height: 1.5;
+  white-space: pre;
+}
+
+.vscode-show {
+  display: flex;
+  justify-content: center;
+  padding: 8px;
+}
+
+.vscode-button {
+  width: 100%;
+}
+</style>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1,0 +1,52 @@
+{
+  "common": {
+    "yes": "Yes",
+    "cancel": "Cancel"
+  },
+  "setting": {
+    "mcpService": {
+      "title": "Model Context Protocol Services",
+      "noServersAvailable": "No servers available",
+      "noServerSelected": "Select a server to view its configuration",
+      "importFromJson": "Import from JSON",
+      "addMcpServer": "Add MCP Server",
+      "importModalTitle": "Import MCP configuration",
+      "ok": "Import",
+      "cancel": "Cancel",
+      "save": "Save",
+      "name": "Name",
+      "namePlaceholder": "Enter a display name",
+      "description": "Description",
+      "descriptionPlaceholder": "Describe the server",
+      "type": "Type",
+      "stdio": "Stdio",
+      "sse": "Server Sent Events",
+      "streamableHttp": "Streamable HTTP",
+      "command": "Command",
+      "commandPlaceholder": "Command to launch the MCP server",
+      "packageSource": "Package source",
+      "default": "Default",
+      "taobaoNpmMirror": "Taobao NPM Mirror",
+      "tsinghua": "Tsinghua Mirror",
+      "aliyun": "Aliyun Mirror",
+      "ustc": "USTC Mirror",
+      "huaweiCloud": "Huawei Cloud Mirror",
+      "tencentCloud": "Tencent Cloud Mirror",
+      "url": "URL",
+      "args": "Arguments",
+      "argsPlaceholder": "One argument per line",
+      "env": "Environment variables",
+      "envPlaceholder": "KEY=VALUE per line",
+      "deleteConfirmTitle": "Delete server",
+      "deleteConfirmContent": "Are you sure you want to delete this MCP server?",
+      "importJson": "Paste the JSON payload"
+    }
+  },
+  "mcpService": {
+    "connectionFailed": "Connection failed",
+    "importSuccess": "Imported {count} servers",
+    "noValidServer": "No valid server entries found",
+    "importSuccessSingle": "Imported server",
+    "invalidJson": "Invalid JSON payload"
+  }
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,0 +1,15 @@
+import { createApp } from 'vue';
+import Antd from 'ant-design-vue';
+import 'ant-design-vue/dist/reset.css';
+
+import App from './App.vue';
+import { createI18nInstance } from './services/i18n';
+import { createPiniaInstance } from './store/pinia';
+
+const app = createApp(App);
+
+app.use(createPiniaInstance());
+app.use(createI18nInstance());
+app.use(Antd);
+
+app.mount('#app');

--- a/frontend/src/services/i18n.ts
+++ b/frontend/src/services/i18n.ts
@@ -1,0 +1,14 @@
+import { createI18n } from 'vue-i18n';
+
+import en from '../locales/en.json';
+
+type MessageSchema = typeof en;
+
+export function createI18nInstance() {
+  return createI18n<{ message: MessageSchema }, 'en'>({
+    legacy: false,
+    locale: 'en',
+    fallbackLocale: 'en',
+    messages: { en }
+  });
+}

--- a/frontend/src/services/mcp.ts
+++ b/frontend/src/services/mcp.ts
@@ -1,0 +1,11 @@
+import type { McpServer } from '@/store/modules/server';
+
+export async function connect(server: McpServer) {
+  console.debug('Attempting to connect to MCP server', server);
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  const ok = Boolean(server.url || server.command);
+  if (!ok) {
+    throw new Error('Server configuration is incomplete.');
+  }
+  return { ok };
+}

--- a/frontend/src/services/workspace.ts
+++ b/frontend/src/services/workspace.ts
@@ -1,0 +1,32 @@
+export interface FileEntry {
+  path: string;
+  isDirectory: boolean;
+}
+
+const sampleFiles: Record<string, string[]> = {
+  '': ['src/', 'src/components/', 'src/components/Terminal.vue', 'README.md'],
+  'src/': ['src/components/', 'src/main.ts'],
+  'src/components/': ['src/components/Terminal.vue'],
+};
+
+const fileContents: Record<string, string> = {
+  'README.md': '# FlashAgent Workspace\n\nThis is a demo file rendered by the mock workspace service.',
+  'src/components/Terminal.vue': '<template>\n  <div>Example component</div>\n</template>\n'
+};
+
+export async function getFiles(conversationId: string, dirPath: string) {
+  console.debug('getFiles', { conversationId, dirPath });
+  return sampleFiles[dirPath] ?? [];
+}
+
+export async function getFile(conversationId: string, path: string) {
+  console.debug('getFile', { conversationId, path });
+  return {
+    code: fileContents[path] ?? '// File not found in mock workspace.'
+  };
+}
+
+export async function getVsCodeUrl(conversationId: string) {
+  console.debug('getVsCodeUrl', { conversationId });
+  return { vscode_url: 'https://example.com/vscode' };
+}

--- a/frontend/src/store/modules/chat.ts
+++ b/frontend/src/store/modules/chat.ts
@@ -1,0 +1,42 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+
+import emitter from '@/utils/emitter';
+
+type ActionOptions = {
+  action: string;
+  args: {
+    command: string;
+    is_input: boolean;
+    thought: string;
+    blocking: boolean;
+    hidden: boolean;
+    confirmation_state: string;
+  };
+};
+
+class MockSocket {
+  emit(event: string, options: ActionOptions) {
+    if (event !== 'oh_user_action') {
+      return;
+    }
+
+    const command = options.args.command || '';
+    if (command) {
+      emitter.emit('terminal', { type: 'command', content: `$ ${command}` });
+    }
+
+    const response = command
+      ? `Executed command: ${command}`
+      : 'No command provided.';
+
+    emitter.emit('terminal', { type: 'observation', content: response });
+  }
+}
+
+export const useChatStore = defineStore('chat', () => {
+  const conversationId = ref('demo-conversation');
+  const socket = new MockSocket();
+
+  return { conversationId, socket };
+});

--- a/frontend/src/store/modules/server.ts
+++ b/frontend/src/store/modules/server.ts
@@ -1,0 +1,92 @@
+import { defineStore } from 'pinia';
+import { computed, ref } from 'vue';
+
+export interface McpServer {
+  id: string;
+  name: string;
+  description: string;
+  activate: boolean;
+  type: 'stdio' | 'sse' | 'streamableHttp';
+  command: string;
+  registryUrl: string;
+  url: string;
+  args: string[];
+  env: Record<string, string>;
+}
+
+const STORAGE_KEY = 'flashagent.mcpServers';
+
+function createId() {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2, 11);
+}
+
+function loadFromStorage(): McpServer[] {
+  if (typeof window === 'undefined') {
+    return [];
+  }
+
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  if (!stored) return [];
+
+  try {
+    const parsed = JSON.parse(stored) as McpServer[];
+    if (Array.isArray(parsed)) {
+      return parsed.map((server) => ({
+        ...server,
+        id: server.id || createId()
+      }));
+    }
+    return [];
+  } catch (error) {
+    console.error('Failed to parse stored servers', error);
+    return [];
+  }
+}
+
+function persist(servers: McpServer[]) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(servers));
+}
+
+export const useServerStore = defineStore('server', () => {
+  const servers = ref<McpServer[]>([]);
+
+  const fetchServers = () => {
+    servers.value = loadFromStorage();
+  };
+
+  const addServer = (server: Omit<McpServer, 'id'>) => {
+    const entry: McpServer = { ...server, id: createId() };
+    servers.value.push(entry);
+    persist(servers.value);
+  };
+
+  const updateServer = (server: McpServer) => {
+    const index = servers.value.findIndex((item) => item.id === server.id);
+    if (index >= 0) {
+      servers.value[index] = { ...server };
+      persist(servers.value);
+    }
+  };
+
+  const deleteServer = (id: string) => {
+    servers.value = servers.value.filter((server) => server.id !== id);
+    persist(servers.value);
+  };
+
+  const activeServers = computed(() => servers.value.filter((server) => server.activate));
+
+  return {
+    servers,
+    fetchServers,
+    addServer,
+    updateServer,
+    deleteServer,
+    activeServers
+  };
+});

--- a/frontend/src/store/pinia.ts
+++ b/frontend/src/store/pinia.ts
@@ -1,0 +1,10 @@
+import { createPinia } from 'pinia';
+
+let pinia: ReturnType<typeof createPinia> | undefined;
+
+export function createPiniaInstance() {
+  if (!pinia) {
+    pinia = createPinia();
+  }
+  return pinia;
+}

--- a/frontend/src/utils/emitter.ts
+++ b/frontend/src/utils/emitter.ts
@@ -1,0 +1,12 @@
+import mitt from 'mitt';
+
+type Events = {
+  'terminal-visible': boolean;
+  'vscode-visible': boolean;
+  terminal: { type: 'command' | 'observation'; content: string };
+  'file-path': string;
+};
+
+const emitter = mitt<Events>();
+
+export default emitter;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.node.json",
+  "compilerOptions": {
+    "composite": true,
+    "tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo.json",
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"],
+  "references": [
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "NodeNext",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "lib": ["ESNext", "DOM"],
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,17 @@
+import { fileURLToPath, URL } from 'node:url';
+
+import vue from '@vitejs/plugin-vue';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url))
+    }
+  },
+  server: {
+    host: '0.0.0.0',
+    port: 5173
+  }
+});

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+aiohttp>=3.9
+browser-use[memory]==0.2.5
+fastapi>=0.115.0
+playwright>=1.42
+pyobjtojson>=0.3
+uvicorn>=0.34


### PR DESCRIPTION
## Summary
- add a Vite-powered Vue 3 workspace under `frontend/` with Ant Design Vue components for MCP server management, terminal access, and workspace browsing
- wire supporting Pinia stores, mock services, and localization to keep the dashboard functional out of the box
- update repository documentation and ignores to cover the new frontend tooling and build artefacts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d6e207ff74832f813e18c52779b21a