### PR TITLE
Document simple CDP demo flow in examples README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -5,15 +5,11 @@ agents to Chrome and Playwright instances.
 
 ## Available demos
 
-- `advanced_playwright_integration.py` – Launches a shared Chrome instance,
-  registers Playwright-powered actions, and demonstrates end-to-end task
-  execution.
-- `connect_existing_chrome.py` – Reuses an already running Chrome profile and
-  executes a simple DuckDuckGo search.
-- `cdp_duckduckgo_demo.py` – Uses the Chrome DevTools Protocol (CDP) endpoint at
-  `http://localhost:9222` to run a Browser-Use agent without launching a new
-  browser process.
-- `multi_agent_parallel_demo.py` – Spawns three Browser-Use agents in parallel,
-  each with its own temporary profile directory.
+| Script                                          | Description                                                                                                                     |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `advanced_playwright_integration.py`            | Launches a shared Chrome instance, registers Playwright-powered actions, and demonstrates end-to-end task execution.            |
+| `connect_existing_chrome.py`                    | Reuses an already running Chrome profile and executes a simple DuckDuckGo search.                                              |
+| `simple_cdp_demo.py` (`cdp_duckduckgo_demo.py`) | Connects to a running Chrome instance through its CDP endpoint, navigates to DuckDuckGo, and runs the search task with the agent. |
+| `multi_agent_parallel_demo.py`                  | Spawns three Browser-Use agents in parallel, each with its own temporary profile directory.                                     |
 
 All scripts expect the `OPENAI_API_KEY` environment variable to be set.


### PR DESCRIPTION
## Summary
- format the examples README demo list as a table for easier scanning
- clarify that the simple CDP demo connects to an existing endpoint and performs a DuckDuckGo search

## Testing
- No tests (documentation only)


------
https://chatgpt.com/codex/tasks/task_b_68d6f9413b18832fb8a23eae8048ed09